### PR TITLE
Remove unnecessary </a> closing tag

### DIFF
--- a/functions/bulmapress_navwalker.php
+++ b/functions/bulmapress_navwalker.php
@@ -47,10 +47,10 @@ class bulmapress_navwalker extends Walker_Nav_Menu {
 	public function end_el(&$output, $item, $depth = 0, $args = array(), $id = 0 ){
 
 		if(in_array("has_children", $item->classes)) {
-
 			$output .= "</div>";
+		} else {
+			$output .= "</a>";
 		}
-		$output .= "</a>";
 	}
 
 	public function end_lvl (&$output, $depth = 0, $args = array()) {


### PR DESCRIPTION
In case of parent menu item no need to close <a> tag, because it's already closed on the line 35